### PR TITLE
vmsdk: fix Rust dependency and some workflow issue

### DIFF
--- a/.github/workflows/vmsdk-test-python.yaml
+++ b/.github/workflows/vmsdk-test-python.yaml
@@ -6,16 +6,27 @@ on:
       - main
     paths:
       - 'src/python/**/*'
+      - '.github/workflows/vmsdk-test-python.yaml'
   pull_request:
     paths:
       - 'src/python/**/*'
+      - '.github/workflows/vmsdk-test-python.yaml'
   workflow_dispatch:
+
+env:
+  VMSDK_PYTEST_DIR: 'vmsdk_pytest'
 
 jobs:
   vmsdk_pytest:
     runs-on: [self-hosted, tdx-guest]
+    defaults:
+      run:
+        working-directory: ${{env.VMSDK_PYTEST_DIR}}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          path: ${{env.VMSDK_PYTEST_DIR}}
       - name: Run PyTest for VMSDK
         run: |
           set -ex

--- a/.github/workflows/vmsdk-test-rust.yaml
+++ b/.github/workflows/vmsdk-test-rust.yaml
@@ -6,17 +6,23 @@ on:
       - main
     paths:
       - 'src/rust/**/*'
+      - '.github/workflows/vmsdk-test-rust.yaml'
   pull_request:
     paths:
       - 'src/rust/**/*'
+      - '.github/workflows/vmsdk-test-rust.yaml'
   workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
+  VMSDK_RUST_TEST_DIR: vmsdk_rust_test
 
 jobs:
   vmsdk_rust_test:
     runs-on: [self-hosted, tdx-guest]
+    defaults:
+      run:
+        working-directory: ${{env.VMSDK_RUST_TEST_DIR}}
     steps:
       - name: Clean up intermediate files
         continue-on-error: true
@@ -26,7 +32,10 @@ jobs:
           # will fail with permission issue.
           sudo rm -f src/rust/cctrusted_vm/Cargo.lock
           sudo rm -fr src/rust/cctrusted_vm/target
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          path: ${{env.VMSDK_RUST_TEST_DIR}}
       - name: Run tests
         run: |
           cd src/rust/cctrusted_vm/

--- a/src/rust/sample/Cargo.toml
+++ b/src/rust/sample/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/cc-sample-eventlog.rs"
 
 [dependencies]
 cctrusted_vm = { path = "../cctrusted_vm" }
-cctrusted_base = { path = "../../../common/rust/cctrusted_base" }
+cctrusted_base = { git = "https://github.com/cc-api/cc-trusted-api.git", branch = "main" }
 anyhow = "1.0"
 log = "0.4.20"
 env_logger = "0.10.1"


### PR DESCRIPTION
Mainly 2 changes:
1. Point the dependency of Rust sample to cc-trusted-api.
2. Avoid intererence among different jobs by separate dirs.