### PR TITLE
vmsdk-test-python.yaml: clean intermediate files

### DIFF
--- a/.github/workflows/vmsdk-test-python.yaml
+++ b/.github/workflows/vmsdk-test-python.yaml
@@ -23,6 +23,13 @@ jobs:
       run:
         working-directory: ${{env.VMSDK_PYTEST_DIR}}
     steps:
+      - name: Clean up intermediate files
+        continue-on-error: true
+        run: |
+          # Remove the intermediate files that could be left
+          # by previous run with sudo. Otherwise, the checkout
+          # will fail with permission issue.
+          sudo rm -fr ./*
       - name: Checkout repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Some files like the venv could be left by previous running with sudo.
But the actions/checkout will try to remove them without permission.
So we need to clean these file before checkout.