### PR TITLE
vmsdk/rust: algin interface of event logs replay

### DIFF
--- a/src/rust/cctrusted_vm/src/cvm.rs
+++ b/src/rust/cctrusted_vm/src/cvm.rs
@@ -1,6 +1,5 @@
 use crate::tdvm::TdxVM;
 use anyhow::*;
-use cctrusted_base::api_data::ReplayResult;
 use cctrusted_base::cc_type::*;
 use cctrusted_base::tcg::EventLogEntry;
 use cctrusted_base::tcg::{TcgAlgorithmRegistry, TcgDigest};
@@ -61,25 +60,6 @@ pub trait CVM {
         start: Option<u32>,
         count: Option<u32>,
     ) -> Result<Vec<EventLogEntry>, anyhow::Error>;
-
-    /***
-        replay retrived CVM eventlogs
-        Args:
-            array of eventlogs
-        Returns:
-            A struct containing the replay result arranged by IMR index and hash algorithm.
-            Layer 1 key of the struct is the IMR index, the value is another dict which using the
-            hash algorithm as the key and the replayed measurement as value.
-            Sample value:
-                [
-                    0: [{ 4: <measurement_replayed>},{ 12: <measurement_replayed>},]
-                    1: { 12: <measurement_replayed>},
-                ]
-    */
-    fn replay_eventlog(
-        &self,
-        eventlogs: Vec<EventLogEntry>,
-    ) -> Result<Vec<ReplayResult>, anyhow::Error>;
 
     /***
         retrive CVM type

--- a/src/rust/cctrusted_vm/src/sdk.rs
+++ b/src/rust/cctrusted_vm/src/sdk.rs
@@ -68,16 +68,6 @@ impl CCTrustedApi for API {
         }
     }
 
-    // CCTrustedApi trait function: replay eventlogs of a CVM
-    fn replay_cc_eventlog(
-        eventlogs: Vec<EventLogEntry>,
-    ) -> Result<Vec<ReplayResult>, anyhow::Error> {
-        match build_cvm() {
-            Ok(cvm) => cvm.replay_eventlog(eventlogs),
-            Err(e) => Err(anyhow!("[replay_cc_eventlog] error create cvm: {:?}", e)),
-        }
-    }
-
     // CCTrustedApi trait function: get default algorithm of a CVM
     fn get_default_algorithm() -> Result<Algorithm, anyhow::Error> {
         match build_cvm() {

--- a/src/rust/cctrusted_vm/src/tdvm.rs
+++ b/src/rust/cctrusted_vm/src/tdvm.rs
@@ -2,7 +2,6 @@
 
 use crate::cvm::*;
 use anyhow::*;
-use cctrusted_base::api_data::ReplayResult;
 use cctrusted_base::cc_type::*;
 use cctrusted_base::eventlog::EventLogs;
 use cctrusted_base::tcg::*;
@@ -591,13 +590,6 @@ impl CVM for TdxVM {
 
         let mut eventlogs = EventLogs::new(boot_time_data, run_time_data, TCG_PCCLIENT_FORMAT);
         eventlogs.select(start, count)
-    }
-
-    fn replay_eventlog(
-        &self,
-        eventlogs: Vec<EventLogEntry>,
-    ) -> Result<Vec<ReplayResult>, anyhow::Error> {
-        EventLogs::replay(eventlogs, TdxRTMR::max_index().into())
     }
 
     // CVM trait function: retrive CVM type


### PR DESCRIPTION
Replay event logs is a common interface and has been moved to CCTrustedApi trait, refer: https://github.com/cc-api/cc-trusted-api/pull/116