### PR TITLE
setupenv.sh: Fix issues

### DIFF
--- a/setupenv.sh
+++ b/setupenv.sh
@@ -3,14 +3,13 @@
 CURR_DIR=$(pwd)
 
 # setup virtualenv and PYTHONPATH
-apt-get install -y python3-virtualenv
+apt-get update && apt-get install -y python3-virtualenv
 
 if [[ ! -d ${CURR_DIR}/venv ]]; then
     python3 -m virtualenv -p python3 ${CURR_DIR}/venv
     source ${CURR_DIR}/venv/bin/activate
     python3 -m pip install "cctrusted_base @ git+https://github.com/cc-api/cc-trusted-api.git#subdirectory=common/python"
     python3 -m pip install -r $CURR_DIR/src/python/requirements.txt
-    export PYTHONPATH=$PYTHONPATH:$CURR_DIR/src/python
     if [ ! $? -eq 0 ]; then
         echo "Failed to install python PIP packages, please check your proxy (https_proxy) or setup PyPi mirror."
         deactivate
@@ -20,3 +19,5 @@ if [[ ! -d ${CURR_DIR}/venv ]]; then
 else
     source ${CURR_DIR}/venv/bin/activate
 fi
+
+export PYTHONPATH=$PYTHONPATH:$CURR_DIR/src/python


### PR DESCRIPTION
1. Fix issue: when venv exists PYTHONPATH will not be set
2. Do apt update before installing python3-virtualenv to avoid issue "package cannot be found"