### PR TITLE
vmsdk/rust: get TSM report from the directory in environment variable

### DIFF
--- a/src/rust/cctrusted_vm/src/sdk.rs
+++ b/src/rust/cctrusted_vm/src/sdk.rs
@@ -44,7 +44,7 @@ impl CCTrustedApi for API {
     // CCTrustedApi trait function: get measurements of a CVM
     fn get_cc_measurement(index: u8, algo_id: u16) -> Result<TcgDigest, anyhow::Error> {
         match build_cvm() {
-            Ok(cvm) => cvm.process_cc_measurement(index, algo_id),
+            Ok(mut cvm) => cvm.process_cc_measurement(index, algo_id),
             Err(e) => Err(anyhow!("[get_cc_measurement] error create cvm: {:?}", e)),
         }
     }


### PR DESCRIPTION
Some updates when TSM is supported:

- Support to get TSM report from the directory defining in the environment variable `TSM_REPORT`
- Get the TEE type from the TSM provider
- Get the measurement from the TSM report
